### PR TITLE
Split the docker-compose and add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+Docker compose file for setting up a EFK service
+================================================
+
+A basic docker compose file that will set up Elasticsearch, Fluentd, and Kibana.
+
+Example
+-------
+
+The file `example/httpd.yml` shows how to configure a service to use EFK as its logging facility. To test using this file, just run:
+
+    docker-compose -f docker-compose.yml -f example/httpd.yml up
+
+Then, go to your browser and access `http://localhost:8080` (httpd) and `http://localhost:5601` (kibana). You should be able to see the httpd's logs in kibana's discovery tab. By the way, if you are wondering what is this index kibana asks the fist time you access it, it is `fluentd-*`.
+
+After you are done, just run:
+
+    docker-compose -f docker-compose.yml -f example/httpd.yml rm -f
+
+And all services will be reclaimed.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: '2'
 services:
-  web:
-    image: httpd
-    ports:
-      - "80:80"
-    links:
-      - fluentd
-    logging:
-      driver: "fluentd"
-      options:
-        fluentd-address: localhost:24224
-        tag: httpd.access
 
   fluentd:
     build: ./fluentd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,12 @@ services:
     ports:
       - "24224:24224"
       - "24224:24224/udp"
-  
+    logging:
+        driver: "json-file"
+        options:
+            max-size: 100m
+            max-file: "5"
+
   elasticsearch:
     image: elasticsearch:5.3.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,12 @@ services:
       - "24224:24224/udp"
   
   elasticsearch:
-    image: elasticsearch
-    expose:
-      - 9200
-    ports:
-      - "9200:9200"
+    image: elasticsearch:5.3.0
 
   kibana:
-    image: kibana
+    image: kibana:5.3.0
     links:
       - "elasticsearch"
     ports:
       - "5601:5601"
+

--- a/example/httpd.yml
+++ b/example/httpd.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  web:
+    image: httpd:2.2.32
+    ports:
+      - "80:8080"
+    depends_on:
+      - fluentd
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: httpd.access
+

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,2 +1,4 @@
 FROM fluent/fluentd:v0.12
+
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri", "--version", "1.9.2"]
+


### PR DESCRIPTION
In order to ease the use of the docker-compose.yml, these patches split it into the actual docker-compose.yml and an example/httpd.yml. This way, users are able to use the docker-compose as it is. Besides that, these patches add a README explaining how users can test the set-up and also hardcode the version of the images to provide reproducibility of deployment.