### PR TITLE
Upgrade fluent-plugin-elasticsearch to 1.9.5

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,2 +1,2 @@
 FROM fluent/fluentd:v0.12
-RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri", "--version", "1.9.2"]
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri", "--version", "1.9.5"]


### PR DESCRIPTION
fluent-plugin-elasticsearch needs an upgrade to avoid deprecation warnings by recent versions of elasticsearch which require a Content-Header.

https://github.com/uken/fluent-plugin-elasticsearch/issues/268